### PR TITLE
Removed useless variable from basic setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ use modio::{Credentials, Modio, Result};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let mut rt = Runtime::new()?;
     let modio = Modio::new(
         Credentials::new("user-or-game-apikey"),
     )?;


### PR DESCRIPTION
There are a few problems with this variable:

1. It's nevers used
2. `Runtime::new()` returns result with `std::io::Error` but in function main declared result with `modio::Error`. It will not compile because of types mismatch.
3. You cannot have 2 tokio runtimes at one time. First one was created by `#[tokio::main]` macro. When you try to create one more it should panic.

So i think it should be removed